### PR TITLE
Correction on usage of TGW with DX-GW outside US

### DIFF
--- a/doc_source/direct-connect-transit-gateways.md
+++ b/doc_source/direct-connect-transit-gateways.md
@@ -23,7 +23,7 @@ The following rules apply:
 + You cannot attach a Direct Connect gateway to a transit gateway when the Direct Connect gateway is already associated with a virtual private gateway or is attached to a private virtual interface\.
 + There are limits for creating and using Direct Connect gateways\. For more information, see [AWS Direct Connect Limits](limits.md)\.
 + A Direct Connect gateway supports communication between attached transit virtual interfaces and associated transit gateways only\. 
-+ The transit virtual interface can be in any location, but currently the transit gateway must reside in the United States\.
++ The transit virtual interface can be in any location\.
 
 For information about the Regions that support transit gateway associations, see [Use AWS Transit Gateway & Direct Connect to Centralize and Streamline Your Network Connectivity](https://aws.amazon.com/blogs/aws/use-aws-transit-gateway-direct-connect-to-centralize-and-streamline-your-network-connectivity/) at the AWS News Blog website\. 
 


### PR DESCRIPTION
Removed sub-sentence ", but currently the transit gateway must reside in the United States" as TGW outside the US have become available in the meantime (see this documentation page itself for new non-US TGW locations) and can be successfully associated with a DX-GW.

*Issue #, if available:* Incorrect statement regarding interchangeability between TGW and DX-GW

*Description of changes:* Removed incorrect sub-sentence


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
