### PR TITLE
Update maximum_resiliency.md

### DIFF
--- a/doc_source/maximum_resiliency.md
+++ b/doc_source/maximum_resiliency.md
@@ -1,6 +1,6 @@
 # Maximum Resiliency<a name="maximum_resiliency"></a>
 
-You can achieve maximum resiliency for critical workloads by using separate connections that terminate on separate devices in more than one location \(as shown in the following figure\)\. This model provides resiliency against device, connectivity, and complete location failures\.
+You can achieve maximum resiliency for critical workloads by using separate connections that terminate on separate devices in more than one location \(as shown in the following figure\)\. This model provides resiliency against device, connectivity, and complete location failures\. The following figure shows both connections from each customer data center going to the same AWS Direct Connect locations. It's also an option to have each connection from a customer data center going to different Direct Connect locations.
 
 ![\[Maximum Resiliency Model\]](http://docs.aws.amazon.com/directconnect/latest/UserGuide/images/dc-max-resiliency.png)
 


### PR DESCRIPTION
The direct connect Maximum resiliency design at https://docs.aws.amazon.com/directconnect/latest/UserGuide/maximum_resiliency.html shows both connections from a customer data center going to the same Direct Connect location.
If there is a failure of a DX location it would isolate a customer DC and force the traffic via the customer data center interconnect links (customer dc to customer dc) before going to AWS. 
This proposed change on the documentation is to clarify that the there are no restrictions to connect from a single customer data center to multiple DX locations. In fact, this may be desirable.
This proposed update to the documentation was discussed with Steve Seymour as well.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
