### PR TITLE
Incorrect Step in Creating a Private VIF

### DIFF
--- a/doc_source/create-vif.md
+++ b/doc_source/create-vif.md
@@ -89,7 +89,7 @@ If you use the VPC wizard to create a VPC, route propagation is automatically en
 
    1. For **Gateway type**, choose **Virtual private gateway**, or **Direct Connect gateway**\. 
 
-   1. For **Virtual interface owner**, choose **Another AWS account**, and then enter the AWS account\. 
+   1. For **Virtual interface owner**, choose **My AWS account** if the virtual interface is for your AWS account\. 
 
    1. For **Virtual private gateway**, choose the virtual private gateway to use for this interface\.
 


### PR DESCRIPTION

*Issue #, if available:* Incorrect Step in Creating a Private VIF

*Description of changes:*

Basically, the difference between a "Hosted" Private VIF and a regular Private VIF is the value of its "Virtual interface owner". For Hosted Private VIF, this field must be "Another AWS account" and then you have to enter the other AWS account. For the regular Private VIF, it must be set to "My Account", just like what is shown in steps for creating a Public VIF.

The step to configure the "Virtual interface owner" field for the regular Private VIF is wrong. It is set to "Another AWS Account" instead of "My Account". In effect, the steps you are showing here is for "Hosted" Private VIF. These two types are quite similar to each other, and the "Virtual interface owner" field is its sole differentiator.

As per this AWS Knowledge Brief: 

Hosted VIFs can connect to public resources or an Amazon Virtual Private Cloud (Amazon VPC) in the same way as standard VIFs. However, the account that owns the VIF is different from the connection owner.  

Reference: 
https://aws.amazon.com/premiumsupport/knowledge-center/direct-connect-types/


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
