### PR TITLE
Update routing-and-bgp.md

### DIFF
--- a/doc_source/routing-and-bgp.md
+++ b/doc_source/routing-and-bgp.md
@@ -25,7 +25,7 @@ The following outbound routing policies apply:
 
 Consider the configuration where the AWS Direct Connect location 1 home Region is the same as the VPC 1 home Region\. The AWS Direct Connect location 2 and AWS Direct Connect location 3 are homed to Regions that are different from the VPC 1 home Region\. In this case, there are no community tags on the routes that are advertised from the on\-premises location to location 1\.
 
-### All Private virtual interfaces or transit virtual interfaces terminate on a virtual private gateway<a name="virtual-private-gateway"></a>
+### All Private virtual interfaces or transit virtual interfaces terminate on a Direct Connect gateway<a name="virtual-private-gateway"></a>
 
 Consider the configuration where the AWS Direct Connect location 1 home Region is the same as the VPC 1 home Region\. The AWS Direct Connect location 2 and the AWS Direct Connect location 3 are homed to Regions that are different from the VPC 1 home Region\. In this case, there are no community tags and AS PATH prepending on the routes that are advertised from the on\-premises location to location 1\.
 


### PR DESCRIPTION
1) Corrected the title in line #28 to match with the picture below that clearly show that the connections terminate on a DXGW (Direct Connect Gateway) and not on a VGW
2) Please remove lines #24 - #26 for the section, at least for now.

---
### All Private virtual interfaces or transit virtual interfaces terminate on a Direct Connect gateway<a name="direct-connect-gateway"></a>

Consider the configuration where the AWS Direct Connect location 1 home Region is the same as the VPC 1 home Region\. The AWS Direct Connect location 2 and AWS Direct Connect location 3 are homed to Regions that are different from the VPC 1 home Region\. In this case, there are no community tags on the routes that are advertised from the on\-premises location to location 1\."
----

The reason being, if you read this section, it is incomplete, confusing and seem to imply that there is suppose to be some picture/diagram to go along with this just like the next section explaining the scenario which is missing? and if so, the text itself make no sense whatsoever. So, better to remove temp, fix and then inset it back as/when it is deemed to be complete.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
