### PR TITLE
Update allowed-to-prefixes.md

### DIFF
--- a/doc_source/allowed-to-prefixes.md
+++ b/doc_source/allowed-to-prefixes.md
@@ -4,7 +4,7 @@ Learn how allowed prefixes interact with transit gateways and virtual private ga
 
 ## Virtual private gateway associations<a name="allowed-to-prefixes-virtual-private-gateway"></a>
 
-The prefix list acts as a filter that allows the same CIDRs, or a smaller range of CIDRs to be advertised to the Direct Connect gateway\. You must set the prefixes to a range that is the same or wider than the VPC CIDR block\.
+The prefix list (IPv4 and IPv6) acts as a filter that allows the same CIDRs, or a smaller range of CIDRs to be advertised to the Direct Connect gateway\. You must set the prefixes to a range that is the same or wider than the VPC CIDR block\.
 
 Consider the scenario where you have a VPC with CIDR 10\.0\.0\.0/16 is attached to a virtual private gateway\.
 + When the allowed prefixes list is set to 22\.0\.0\.0/24, you do not receive any route because 22\.0\.0\.0/24 is not the same as, or wider than 10\.0\.0\.0/16\.


### PR DESCRIPTION
Line #7 added for clarity that Allowed Prefixes option also covers IPv6. No where in the DX docs this is mentioned even though you can add IPv6 in the Allowed Prefixes thus cause confusion implying that Allowed Prefixes only support IPv4

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
