### PR TITLE
Correct capitalization in Direct Connect gateways intro

### DIFF
--- a/doc_source/direct-connect-gateways-intro.md
+++ b/doc_source/direct-connect-gateways-intro.md
@@ -40,7 +40,7 @@ For information about configuring transit gateways, see [Working with Transit Ga
 
 ## Transit gateway associations across accounts<a name="transit-gateway-across-accounts"></a>
 
-Consider this scenario of a Direct Connect gateway owner \(Account Z\) who owns the Direct Connect gateway\. Account A owns the transit gateway and wants to use the Direct Connect gateway\. Account Z accepts the association proposals and can optionally update the prefixes that are allowed from Account A's transit gateway\. After Account Z accepts the proposals, The VPCs attached to the transit gateway can route traffic from the transit gateway to the Direct Connect gateway\. Account Z also owns the routing to the customers because Account Z owns the gateway\.
+Consider this scenario of a Direct Connect gateway owner \(Account Z\) who owns the Direct Connect gateway\. Account A owns the transit gateway and wants to use the Direct Connect gateway\. Account Z accepts the association proposals and can optionally update the prefixes that are allowed from Account A's transit gateway\. After Account Z accepts the proposals, the VPCs attached to the transit gateway can route traffic from the transit gateway to the Direct Connect gateway\. Account Z also owns the routing to the customers because Account Z owns the gateway\.
 
 ![\[Image NOT FOUND\]](http://docs.aws.amazon.com/directconnect/latest/UserGuide/images/direct-connect-ma-tgw.png)
 


### PR DESCRIPTION
Correct capitalization error: "the proposals, The VPCs " -> " the proposals, the VPCs "

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
