### PR TITLE
Update multi-account-associate-vgw.md

### DIFF
--- a/doc_source/multi-account-associate-vgw.md
+++ b/doc_source/multi-account-associate-vgw.md
@@ -1,6 +1,6 @@
 # Associating a virtual private gateway across accounts<a name="multi-account-associate-vgw"></a>
 
-You can associate a Direct Connect gateway with a virtual private gateway that is owned by any AWS account\. The Direct Connect gateway can be an existing gateway, or you can create a new gateway\. The owner of the virtual private gateway creates an *association proposal* and the owner of the Direct Connect gateway must accept the association proposal\.
+You can associate a Direct Connect gateway with a virtual private gateway that is owned by any AWS account\. The Amazon VPCs and the Direct Connect gateway must be owned by AWS Accounts that belong to the same AWS payer account ID\. The Direct Connect gateway can be an existing gateway, or you can create a new gateway\. The owner of the virtual private gateway creates an *association proposal* and the owner of the Direct Connect gateway must accept the association proposal\.
 
 An association proposal can contain prefixes that will be allowed from the virtual private gateway\. The owner of the Direct Connect gateway can optionally override any requested prefixes in the association proposal\.
 


### PR DESCRIPTION
Added a sentence in line #3 which is a key requirement called out in: https://aws.amazon.com/about-aws/whats-new/2019/03/announcing-multi-account-support-for-direct-connect-gateway/ but is not mentioned here. I wonder as to why this is called in the announcement and not here in the docs?.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
