### PR TITLE
Update routing-and-bgp.md

### DIFF
--- a/doc_source/routing-and-bgp.md
+++ b/doc_source/routing-and-bgp.md
@@ -92,7 +92,7 @@ If you do not specify local preference using BGP community tags, the default out
 
 #### `NO_EXPORT` BGP community<a name="no-export-bgp-communities-privatre-transit"></a>
 
-The `NO_EXPORT` BGP community tag is supported for public virtual interfaces, private virtual interfaces, and transit virtual interfaces\.
+The `NO_EXPORT` BGP community tag is supported for public virtual interfaces\.
 
 AWS Direct Connect also provides BGP community tags on advertised Amazon routes\. If you use AWS Direct Connect to access public AWS services, you can create filters based on these community tags\. 
 


### PR DESCRIPTION
NO_EXPORT section starting at line #93 is a) redundant/duplicate of the same section starting at line #55 and b) NO_EXPORT only apply to Public Vifs, not to Private/Transit Vif as mentioned on line #95, hence removed. Suggest to remove the duplicate section altogether to avoid confusion.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
