### PR TITLE
Update direct-connect-mac-sec-getting-started.md

### DIFF
--- a/doc_source/direct-connect-mac-sec-getting-started.md
+++ b/doc_source/direct-connect-mac-sec-getting-started.md
@@ -20,7 +20,7 @@ Complete the following tasks before you configure MACsec on a dedicated connecti
 + Create a CKN/CAK pair for the MACsec secret key\.
 
   You can create the pair using an open standard tool\. The pair must meet the requirements specified in [Step 4: Configure your on\-premises router](#associate-key-router)\.
-+ MACsec is available on dedicated connections for certain AWS Direct Connect Partners\. For information about which AWS Direct Connect Partners support MACsec, see [AWS Direct Connect](https://aws.amazon.com/directconnect/?nc=sn&loc=0)\.
++ MACsec is available only on dedicated 10G and 100G connections.
 + Make sure that you have a device on your end of the connection that supports MACsec\.
 
 ## Service\-Linked roles<a name="mac-sec-service-linked-roles"></a>


### PR DESCRIPTION
"MACsec is available on dedicated connections for certain AWS Direct Connect Partners. " directly contradicts the FAQs: https://aws.amazon.com/directconnect/faqs/ "Q. Which type of AWS Direct Connect connections support MACsec?" --> "MACsec is not supported on 1 Gbps dedicated connections or any hosted connections." Partners only provide hosted connections, not dedicated connections. So the original sentence make no sense.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
