### PR TITLE
fix: Update link for Infrastructure secuity

### DIFF
--- a/doc_source/infrastructure-security.md
+++ b/doc_source/infrastructure-security.md
@@ -1,6 +1,6 @@
 # Infrastructure security in AWS Direct Connect<a name="infrastructure-security"></a>
 
-As a managed service, AWS Direct Connect is protected by the AWS global network security procedures that are described in the [Amazon Web Services: Overview of Security Processes](https://d0.awsstatic.com/whitepapers/Security/AWS_Security_Whitepaper.pdf) whitepaper\.
+As a managed service, AWS Direct Connect is protected by the AWS global network security procedures that are described in the [Introduction to AWS Security](https://docs.aws.amazon.com/whitepapers/latest/introduction-aws-security/) whitepaper\.
 
 You use AWS published API calls to access AWS Direct Connect through the network\. Clients must support Transport Layer Security \(TLS\) 1\.0 or later\. We recommend TLS 1\.2 or later\. Clients must also support cipher suites with perfect forward secrecy \(PFS\) such as Ephemeral Diffie\-Hellman \(DHE\) or Elliptic Curve Ephemeral Diffie\-Hellman \(ECDHE\)\. Most modern systems such as Java 7 and later support these modes\.
 


### PR DESCRIPTION
Old link goes to an archived whitepaper from March 2020

*Issue #, if available: #63 

*Description of changes: Old link goes to a archived whitepaper from March 2020


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
