### PR TITLE
LAG and VIF limits

### DIFF
--- a/doc_source/limits.md
+++ b/doc_source/limits.md
@@ -5,12 +5,11 @@ The following table lists the quotas related to AWS Direct Connect\. Unless indi
 
 | Component | Quota | Comments | 
 | --- | --- | --- | 
-|  Private or public virtual interfaces per AWS Direct Connect dedicated connection  |  50  |  This limit cannot be increased\.  | 
-| Transit virtual interfaces per AWS Direct Connect dedicated connection |  4  | This limit cannot be increased\. | 
+| Private or public virtual interfaces per AWS Direct Connect dedicated connection or Link Aggregation Group \(LAG\) |  50  |  This limit cannot be increased\.  | 
+| Transit virtual interfaces per AWS Direct Connect dedicated connection or Link Aggregation Group \(LAG\) |  4  | This limit cannot be increased\. | 
 | Private or public virtual interfaces per AWS Direct Connect dedicated connection and transit virtual interfaces per AWS Direct Connect dedicated connection | 50 and 1 transit virtual interface | This limit cannot be increased\. | 
 | Private, public, or transit virtual interfaces per AWS Direct Connect hosted connection | 1 | This limit cannot be increased\. | 
 |  Active AWS Direct Connect connections per Direct Connect location per Region per account  | 10 | Contact your Solutions Architect \(SA\) or Technical Account Manager \(TAM\) for further assistance\. | 
-| Number of virtual interfaces per Link Aggregation Group \(LAG\) | 50 |  | 
 |  Routes per Border Gateway Protocol \(BGP\) session on a private virtual interface or transit virtual interface If you advertise more than 100 routes each for IPv4 and IPv6 over the BGP session, the BGP session will go into an idle state with the BGP session DOWN\.  |  100 each for IPv4 and IPv6  |  This limit cannot be increased\.  | 
 |  Routes per Border Gateway Protocol \(BGP\) session on a public virtual interface  |  1,000  |  This limit cannot be increased\.  | 
 |  Dedicated connections per link aggregation group \(LAG\)  | 4 when the port speed is less than 100G 2 when the port speed is 100G |  | 


### PR DESCRIPTION
*Issue #, if available:*
Current line item for "Number of virtual interfaces per Link Aggregation Group (LAG) is confusing, as it doesn't clarify the type of virtual interface. 

*Description of changes:*
Clarify that a LAG is treated like a standard dedicated connection for VIF limits, therefore supporting up to 50 private or public VIFs and up to 4 Transit VIFs. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
